### PR TITLE
Update problems.jl

### DIFF
--- a/src/problems.jl
+++ b/src/problems.jl
@@ -14,7 +14,7 @@ function HestonProblem(μ, κ, Θ, σ, ρ, u0, tspan; seed = UInt64(0), kwargs..
     end
     g = function (du, u, p, t)
         du[1] = √u[2] * u[1]
-        du[2] = Θ * √u[2]
+        du[2] = σ * √u[2]
     end
     Γ = [1 ρ; ρ 1] # Covariance Matrix
     noise_rate_prototype = nothing


### PR DESCRIPTION
Replace Θ with σ in the diffusion coefficient of Heston volatility process. Currently, while σ is an input parameter, it is unused in the problem definition and long run mean Θ is used instead.