### PR TITLE
Cox Ingersoll Ross problem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqFinancial"
 uuid = "5a0ffddc-d203-54b0-88ba-2c03c0fc2e67"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "v2.6.0"
+version = "2.6.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -17,9 +17,10 @@ RandomNumbers = "1"
 julia = "1.6"
 
 [extras]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Statistics", "StochasticDiffEq"]
+test = ["Test", "Statistics", "StochasticDiffEq", "Distributions"]

--- a/src/DiffEqFinancial.jl
+++ b/src/DiffEqFinancial.jl
@@ -10,6 +10,7 @@ include("problems.jl")
 export HestonProblem, BlackScholesProblem, GeneralizedBlackScholesProblem,
        ExtendedOrnsteinUhlenbeckProblem, OrnsteinUhlenbeckProblem,
        GeometricBrownianMotionProblem,
-       MfStateProblem
+       MfStateProblem,
+       CIRProblem
 
 end # module

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -134,3 +134,31 @@ function MfStateProblem(a, σ, u0, tspan; kwargs...)
     end
     SDEProblem{false}(f, g, u0, tspan; kwargs...)
 end
+
+@doc doc"""
+
+``dr = κ(θ - r)dt + σ√r dW_t``
+
+The Cox-Ingersoll-Ross (CIR) model is commonly used for short-rate modeling in interest rate theory.
+
+- `κ` is the speed of mean reversion
+- `θ` is the long-term mean level
+- `σ` is the volatility
+- `r(t)` is the short rate
+
+Constraints for Feller condition: `2κθ ≥ σ²` to ensure positivity of `r(t)`.
+
+"""
+function CIRProblem(κ, θ, σ, u0, tspan; kwargs...)
+    if 2κ * θ < σ^2
+        @warn "Feller condition 2κθ ≥ σ² is violated. The CIR process may reach zero."
+    end
+    
+    f = function (u, p, t)
+        κ * (θ - u)
+    end
+    g = function (u, p, t)
+        σ * sqrt(u)
+    end
+    SDEProblem{false}(f, g, u0, tspan; kwargs...)
+end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -144,17 +144,8 @@ end
 
 The Cox-Ingersoll-Ross (CIR) model is commonly used for short-rate modeling in interest rate theory.
 
-- `κ` is the speed of mean reversion
-- `θ` is the long-term mean level
-- `σ` is the volatility
-- `r` is the short rate
-
-Constraints for Feller condition: `2κθ ≥ σ²` to ensure positivity of `r(t)`.
-
-This constructor sets up a stochastic differential equation (SDE) problem representing the CIR model. It defines drift and diffusion functions based on the model parameters and returns a `SDEProblem` suitable for simulation using `DifferentialEquations.jl`.
-
 ### Keyword Arguments
-- `modifier`: A function applied inside the square root in the diffusion term. By default, modifier ensures numerical stability when `r(t)` becomes slightly negative due to discretization errors. Without this, the square root of a negative number would result in a domain error. You may override this if using an alternative regularization strategy or if you're certain `r(t)` will remain positive.
+- `modifier`: A function applied inside the square root in the diffusion term. It ensures rate positivity which can break due to discretization error.
 
 """
 function CIRProblem(κ, θ, σ, u0, tspan; modifier=x->max(x,0), kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using DiffEqFinancial, Statistics, StochasticDiffEq
+using DiffEqFinancial, Statistics, StochasticDiffEq, Distributions
 using Test
 
 # write your own tests here
@@ -28,4 +28,22 @@ simulated = mean(us)
 tsteps = collect(0:dt:T)
 expected = S0 * exp.(r * tsteps)
 testerr = sum(abs2.(simulated .- expected))
+@test testerr < 2e-1
+
+κ, θ, σ, u0, tspan =  0.30, 0.04, 0.15, 0.2, (0.0, 1.0)
+prob = CIRProblem(κ, θ, σ, u0, tspan)
+sol = solve(prob, EM(); dt = dt)
+monte_prob = EnsembleProblem(prob)
+sol = solve(monte_prob, EM(); dt = dt, trajectories = 1000000)
+us = [sol.u[i].u for i in eachindex(sol)]
+simulated = mean(us)
+
+d = 4 * κ * θ / σ^2  # Degrees of freedom
+λ(t) = 4 * κ * exp(-κ * t) * u0 / (σ^2 * (-expm1(-κ * t)))  # Noncentrality parameter
+c(t) = σ^2 * (-expm1(-κ * t)) / (4 * κ)  # Scaling factor
+dist(t) = c(t) * Distributions.mean(NoncentralChisq(d, λ(t)))
+
+tsteps = collect(dt:dt:T) 
+expected = dist.(tsteps)
+testerr = sum(abs2.(simulated[2:end] .- expected))
 @test testerr < 2e-1


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Added CIRProblem (https://en.wikipedia.org/wiki/Cox%E2%80%93Ingersoll%E2%80%93Ross_model).
Added modifier to make Heston simulation not break when the second component becomes negative (which happens due to discretization error).