### PR TITLE
CIR exact simulation using non-centered chi-squared sample

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "2.7.0"
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"

--- a/src/DiffEqFinancial.jl
+++ b/src/DiffEqFinancial.jl
@@ -1,7 +1,7 @@
 __precompile__()
 
 module DiffEqFinancial
-using DiffEqBase, DiffEqNoiseProcess, Markdown, LinearAlgebra
+using DiffEqBase, DiffEqNoiseProcess, Markdown, LinearAlgebra, Distributions
 
 import RandomNumbers: Xorshifts
 
@@ -11,6 +11,7 @@ export HestonProblem, BlackScholesProblem, GeneralizedBlackScholesProblem,
        ExtendedOrnsteinUhlenbeckProblem, OrnsteinUhlenbeckProblem,
        GeometricBrownianMotionProblem,
        MfStateProblem,
-       CIRProblem
+       CIRProblem,
+       CIRNoise
 
 end # module

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -162,15 +162,22 @@ function CIRProblem(κ, θ, σ, u0, tspan; modifier=x->max(x,0), kwargs...)
     SDEProblem{false}(f, g, u0, tspan; kwargs...)
 end
 
-function CIRNoise(κ, θ, σ, t0, W0, Z0 = nothing; kwargs...)
-    
-    @inline function CIR_dist(DW, W, dt, u, p, t, rng) #dist
-        d = 4 * κ * θ / σ^2  # Degrees of freedom
-        λ = - 4 * κ * exp(-κ * T) * V0 / (σ^2 * expm1(-κ * T))  # Noncentrality parameter
-        c = - σ^2 * expm1(-κ * T) / 4κ  # Scaling factor
-        V_T = c * Distributions.rand(rng, NoncentralChisq(d, λ))
-        return V_T - W[end][2]
-    end
+struct CoxIngersollRoss{T1, T2, T3}
+    κ::T1
+    θ::T2
+    σ::T3
+end
 
-    return NoiseProcess{false}(t0, W0, Z0, CIR_dist, nothing)
+function (X::CoxIngersollRoss)(DW, W, dt, u, p, t, rng) #dist
+    κ, θ, σ = X.κ, X.θ, X.σ
+    d = 4 * κ * θ / σ^2  # Degrees of freedom
+    λ = - 4 * κ * exp(-κ * T) * V0 / (σ^2 * expm1(-κ * T))  # Noncentrality parameter
+    c = - σ^2 * expm1(-κ * T) / 4κ  # Scaling factor
+    V_T = c * Distributions.rand(rng, NoncentralChisq(d, λ))
+    return V_T - W[end][2]
+end
+
+function CIRNoise(κ, θ, σ, t0, W0, Z0 = nothing; kwargs...)
+    cir = CoxIngersollRoss(κ, θ, σ)
+    return NoiseProcess{false}(t0, W0, Z0, cir, nothing)
 end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -177,6 +177,14 @@ function (X::CoxIngersollRoss)(DW, W, dt, u, p, t, rng) #dist
     return V_T - W[end][2]
 end
 
+@doc doc"""
+
+``dr = κ(θ - r)dt + σ√r dW_t``
+
+The Cox-Ingersoll-Ross (CIR) model is commonly used for short-rate modeling in interest rate theory.
+This is a distributionally-exact process, leveraging the known χ² transition law of the process.
+The sampling leverages Distributions.jl.
+"""
 function CIRNoise(κ, θ, σ, t0, W0, Z0 = nothing; kwargs...)
     cir = CoxIngersollRoss(κ, θ, σ)
     return NoiseProcess{false}(t0, W0, Z0, cir, nothing)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -161,3 +161,16 @@ function CIRProblem(κ, θ, σ, u0, tspan; modifier=x->max(x,0), kwargs...)
     end
     SDEProblem{false}(f, g, u0, tspan; kwargs...)
 end
+
+function CIRNoise(κ, θ, σ, t0, W0, Z0 = nothing; kwargs...)
+    
+    @inline function CIR_dist(DW, W, dt, u, p, t, rng) #dist
+        d = 4 * κ * θ / σ^2  # Degrees of freedom
+        λ = - 4 * κ * exp(-κ * T) * V0 / (σ^2 * expm1(-κ * T))  # Noncentrality parameter
+        c = - σ^2 * expm1(-κ * T) / 4κ  # Scaling factor
+        V_T = c * Distributions.rand(rng, NoncentralChisq(d, λ))
+        return V_T - W[end][2]
+    end
+
+    return NoiseProcess{false}(t0, W0, Z0, CIR_dist, nothing)
+end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -10,7 +10,8 @@ dW_1 dW_2 = ρ dt
 - `modifier`: A function applied inside the square root in the diffusion term. By default, modifier ensures numerical stability when `u[2]` becomes slightly negative due to discretization errors. Without this, the square root of a negative number would result in a domain error. You may override this if using an alternative regularization strategy or if you're certain `u[2]` will remain positive.
 
 """
-function HestonProblem(μ, κ, Θ, σ, ρ, u0, tspan; seed = UInt64(0), modifier=x->max(x,0), kwargs...)
+function HestonProblem(
+        μ, κ, Θ, σ, ρ, u0, tspan; seed = UInt64(0), modifier = x->max(x, 0), kwargs...)
     f = function (du, u, p, t)
         du[1] = μ * u[1]
         du[2] = κ * (Θ - modifier(u[2]))
@@ -148,11 +149,11 @@ The Cox-Ingersoll-Ross (CIR) model is commonly used for short-rate modeling in i
 - `modifier`: A function applied inside the square root in the diffusion term. It ensures rate positivity which can break due to discretization error.
 
 """
-function CIRProblem(κ, θ, σ, u0, tspan; modifier=x->max(x,0), kwargs...)
+function CIRProblem(κ, θ, σ, u0, tspan; modifier = x->max(x, 0), kwargs...)
     if 2κ * θ < σ^2
         @warn "Feller condition 2κθ ≥ σ² is violated. The CIR process may reach zero."
     end
-    
+
     f = function (u, p, t)
         κ * (θ - modifier(u))
     end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -203,10 +203,10 @@ Returns an increment from the single sample from the exact transition distributi
 function (X::CoxIngersollRoss)(DW, W, dt, u, p, t, rng) #dist
     κ, θ, σ = X.κ, X.θ, X.σ
     d = 4 * κ * θ / σ^2  # Degrees of freedom
-    λ = - 4 * κ * exp(-κ * dt) * W[end] / (σ^2 * expm1(-κ * dt))  # Noncentrality parameter
+    λ = - 4 * κ * exp(-κ * dt) * W.W[end] / (σ^2 * expm1(-κ * dt))  # Noncentrality parameter
     c = - σ^2 * expm1(-κ * dt) / 4κ  # Scaling factor
-    V_T = c * Distributions.rand(rng, NoncentralChisq(d, λ))
-    return V_T - W[end] #return the increment
+    sample = c * Distributions.rand(rng, NoncentralChisq(d, λ))
+    return sample - W.W[end] #return the increment
 end
 
 @doc doc"""

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,0 @@
-[deps]
-DiffEqFinancial = "5a0ffddc-d203-54b0-88ba-2c03c0fc2e67"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+DiffEqFinancial = "5a0ffddc-d203-54b0-88ba-2c03c0fc2e67"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ expected = S0 * exp.(r * tsteps)
 testerr = sum(abs2.(simulated .- expected))
 @test testerr < 2e-1
 
-κ, θ, σ, u0, tspan =  0.30, 0.04, 0.15, 0.2, (0.0, 1.0)
+κ, θ, σ, u0, tspan = 0.30, 0.04, 0.15, 0.2, (0.0, 1.0)
 prob = CIRProblem(κ, θ, σ, u0, tspan)
 sol = solve(prob, EM(); dt = dt)
 monte_prob = EnsembleProblem(prob)
@@ -43,7 +43,7 @@ d = 4 * κ * θ / σ^2  # Degrees of freedom
 c(t) = σ^2 * (-expm1(-κ * t)) / (4 * κ)  # Scaling factor
 dist(t) = c(t) * Distributions.mean(NoncentralChisq(d, λ(t)))
 
-tsteps = collect(dt:dt:T) 
+tsteps = collect(dt:dt:T)
 expected = dist.(tsteps)
 testerr = sum(abs2.(simulated[2:end] .- expected))
 @test testerr < 2e-1
@@ -59,7 +59,7 @@ sol_ex = solve(noise_problem, EM(); dt = dt)
 sol_exact_ens = solve(monte_exact_prob, EM(); dt = dt, trajectories = 1000)
 us_exact = [sol_exact_ens.u[i].u for i in eachindex(sol_exact_ens)]
 
-tsteps = collect(dt:dt:T) 
+tsteps = collect(dt:dt:T)
 expected = dist.(tsteps)
 simulated_exact = mean(us_exact)
 testerr_exact = sum(abs2.(simulated_exact[2:end] .- expected))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,6 @@ dist(t) = c(t) * Distributions.mean(NoncentralChisq(d, λ(t)))
 tsteps = collect(dt:dt:T) 
 expected = dist.(tsteps)
 testerr = sum(abs2.(simulated[2:end] .- expected))
-@show testerr
 @test testerr < 2e-1
 
 dt = 1 / 10.0
@@ -64,5 +63,4 @@ tsteps = collect(dt:dt:T)
 expected = dist.(tsteps)
 simulated_exact = mean(us_exact)
 testerr_exact = sum(abs2.(simulated_exact[2:end] .- expected))
-@show testerr_exact
-@test testerr < 2e-1
+@test testerr_exact < 2e-1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,4 +46,23 @@ dist(t) = c(t) * Distributions.mean(NoncentralChisq(d, λ(t)))
 tsteps = collect(dt:dt:T) 
 expected = dist.(tsteps)
 testerr = sum(abs2.(simulated[2:end] .- expected))
+@show testerr
+@test testerr < 2e-1
+
+dt = 1 / 10.0
+t0 = 0.0
+W0 = u0
+tspan = (0.0, 1.0)
+noise = CIRNoise(κ, θ, σ, t0, W0)
+noise_problem = NoiseProblem(noise, tspan)
+monte_exact_prob = EnsembleProblem(noise_problem)
+sol_ex = solve(noise_problem, EM(); dt = dt)
+sol_exact_ens = solve(monte_exact_prob, EM(); dt = dt, trajectories = 1000)
+us_exact = [sol_exact_ens.u[i].u for i in eachindex(sol_exact_ens)]
+
+tsteps = collect(dt:dt:T) 
+expected = dist.(tsteps)
+simulated_exact = mean(us_exact)
+testerr_exact = sum(abs2.(simulated_exact[2:end] .- expected))
+@show testerr_exact
 @test testerr < 2e-1


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Added CIRNoise to sample Cox Ingersoll Process in a distributionally-exact way. 
I took GeometricBrownianMotionProcess as inspiration. I noticed that in the dist function there W.W[end] is used instead of W[end]. I tried with both for my distribution and I did not notice differences. 