### PR TITLE
[ci-skip] Revert JuliaFormatter PR #31

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,12 +6,12 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 include("pages.jl")
 
 makedocs(sitename = "DiffEqFinancial.jl",
-    authors = "Chris Rackauckas",
-    modules = [DiffEqFinancial],
-    clean = true,
-    doctest = false,
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/DiffEqFinancial/stable/"),
-    pages = pages)
+         authors = "Chris Rackauckas",
+         modules = [DiffEqFinancial],
+         clean = true,
+         doctest = false,
+         format = Documenter.HTML(assets = ["assets/favicon.ico"],
+                                  canonical = "https://docs.sciml.ai/DiffEqFinancial/stable/"),
+         pages = pages)
 
 deploydocs(repo = "github.com/SciML/DiffEqFinancial.jl.git"; push_preview = true)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -27,7 +27,7 @@ function HestonProblem(
         seed = rand(UInt64)
     end
     noise = CorrelatedWienerProcess!(Γ, tspan[1], zeros(2), zeros(2),
-        rng = Xorshifts.Xoroshiro128Plus(seed))
+                                     rng = Xorshifts.Xoroshiro128Plus(seed))
 
     sde_f = SDEFunction{true}(f, g)
     SDEProblem(sde_f, u0, tspan, noise = noise, seed = seed, kwargs...)
@@ -56,7 +56,7 @@ end
 Solves for ``log S(t)``.
 """
 mutable struct BlackScholesProblem{uType, tType, tupType, isinplace, NP, F, F2, C, ND, MM
-} <:
+                                   } <:
                DiffEqBase.AbstractSDEProblem{uType, tType, isinplace, ND}
     r::tType
     Θ::tType
@@ -74,9 +74,9 @@ mutable struct BlackScholesProblem{uType, tType, tupType, isinplace, NP, F, F2, 
 end
 
 function BlackScholesProblem(r, Θ, σ, u0, tspan; callback = CallbackSet(),
-        noise_rate_prototype = nothing, seed = UInt64(0))
+                             noise_rate_prototype = nothing, seed = UInt64(0))
     GeneralizedBlackScholesProblem(r, (t) -> 0, Θ, σ, u0, tspan, callback = callback,
-        seed = seed)
+                                   seed = seed)
 end
 
 @doc doc"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using DiffEqFinancial, Statistics, StochasticDiffEq, Distributions
+using DiffEqFinancial, Statistics, StochasticDiffEq
 using Test
 
 # write your own tests here
@@ -13,54 +13,19 @@ sol = solve(prob, SRIW1())
 r = 0.03
 sigma = 0.2
 S0 = 100
-t = 0
-T = 1.0
+t=0
+T=1.0
 days = 252
-dt = 1 / days
+dt = 1/days
 
-prob = GeometricBrownianMotionProblem(r, sigma, S0, (t, T))
-sol = solve(prob, EM(); dt = dt)
+prob = GeometricBrownianMotionProblem(r, sigma, S0, (t,T))
+sol = solve(prob,EM();dt=dt)
 monte_prob = EnsembleProblem(prob)
-sol = solve(monte_prob, EM(); dt = dt, trajectories = 1000000)
-us = [sol.u[i].u for i in eachindex(sol)]
+sol = solve(monte_prob, EM(); dt=dt,trajectories=1000000)
+us=[sol[i].u for i in eachindex(sol)]
 simulated = mean(us)
 
 tsteps = collect(0:dt:T)
 expected = S0 * exp.(r * tsteps)
 testerr = sum(abs2.(simulated .- expected))
 @test testerr < 2e-1
-
-κ, θ, σ, u0, tspan = 0.30, 0.04, 0.15, 0.2, (0.0, 1.0)
-prob = CIRProblem(κ, θ, σ, u0, tspan)
-sol = solve(prob, EM(); dt = dt)
-monte_prob = EnsembleProblem(prob)
-sol = solve(monte_prob, EM(); dt = dt, trajectories = 1000000)
-us = [sol.u[i].u for i in eachindex(sol)]
-simulated = mean(us)
-
-d = 4 * κ * θ / σ^2  # Degrees of freedom
-λ(t) = 4 * κ * exp(-κ * t) * u0 / (σ^2 * (-expm1(-κ * t)))  # Noncentrality parameter
-c(t) = σ^2 * (-expm1(-κ * t)) / (4 * κ)  # Scaling factor
-dist(t) = c(t) * Distributions.mean(NoncentralChisq(d, λ(t)))
-
-tsteps = collect(dt:dt:T)
-expected = dist.(tsteps)
-testerr = sum(abs2.(simulated[2:end] .- expected))
-@test testerr < 2e-1
-
-dt = 1 / 10.0
-t0 = 0.0
-W0 = u0
-tspan = (0.0, 1.0)
-noise = CIRNoise(κ, θ, σ, t0, W0)
-noise_problem = NoiseProblem(noise, tspan)
-monte_exact_prob = EnsembleProblem(noise_problem)
-sol_ex = solve(noise_problem, EM(); dt = dt)
-sol_exact_ens = solve(monte_exact_prob, EM(); dt = dt, trajectories = 1000)
-us_exact = [sol_exact_ens.u[i].u for i in eachindex(sol_exact_ens)]
-
-tsteps = collect(dt:dt:T)
-expected = dist.(tsteps)
-simulated_exact = mean(us_exact)
-testerr_exact = sum(abs2.(simulated_exact[2:end] .- expected))
-@test testerr_exact < 2e-1


### PR DESCRIPTION
This reverts the JuliaFormatter changes from PR #31 (commit 30c5b08).

The formatting is being reverted because JuliaFormatter had issues with line breaking that have now been addressed in JuliaFormatter.jl PR#933. Once that PR is merged and a new version is released, formatting can be reapplied with better results.

**Note:** This PR has [ci-skip] to avoid running tests since this is just reverting formatting changes.