### PR TITLE
Improve static analysis: Add JET.jl tests and remove deprecated __precompile__()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,13 +15,16 @@ RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 DiffEqBase = "6"
 DiffEqNoiseProcess = "3, 4.1, 5.0"
 Distributions = "0.25.100"
+JET = "0.9, 0.10, 0.11"
 RandomNumbers = "1"
-julia = "1.6"
+julia = "1.10"
+
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Statistics", "StochasticDiffEq", "Distributions"]
+test = ["Test", "Statistics", "StochasticDiffEq", "Distributions", "JET"]

--- a/src/DiffEqFinancial.jl
+++ b/src/DiffEqFinancial.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module DiffEqFinancial
 using DiffEqBase, DiffEqNoiseProcess, Markdown, LinearAlgebra, Distributions
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using DiffEqFinancial, Statistics, StochasticDiffEq
 using Test
+using JET
 
-# write your own tests here
+@testset "DiffEqFinancial.jl" begin
 u0 = [1.0; 0.5]
 σ = 0.25
 prob = HestonProblem(1.0, 1.0, σ, 1.0, 1.0, u0, (0.0, 1.0))
@@ -29,3 +30,36 @@ tsteps = collect(0:dt:T)
 expected = S0 * exp.(r * tsteps)
 testerr = sum(abs2.(simulated .- expected))
 @test testerr < 2e-1
+
+end # testset DiffEqFinancial.jl
+
+@testset "JET static analysis" begin
+    # Test that key problem constructors are type-stable using @test_opt
+    # target_modules filters to only report issues from DiffEqFinancial itself,
+    # ignoring upstream SciMLBase/DiffEqBase issues
+
+    @testset "HestonProblem type stability" begin
+        @test_opt target_modules = (DiffEqFinancial,) HestonProblem(
+            1.0, 1.0, 0.25, 1.0, 1.0, [1.0, 0.5], (0.0, 1.0))
+    end
+
+    @testset "GeometricBrownianMotionProblem type stability" begin
+        @test_opt target_modules = (DiffEqFinancial,) GeometricBrownianMotionProblem(
+            0.03, 0.2, 100.0, (0.0, 1.0))
+    end
+
+    @testset "OrnsteinUhlenbeckProblem type stability" begin
+        @test_opt target_modules = (DiffEqFinancial,) OrnsteinUhlenbeckProblem(
+            0.1, 0.5, 0.2, 1.0, (0.0, 1.0))
+    end
+
+    @testset "CIRProblem type stability" begin
+        @test_opt target_modules = (DiffEqFinancial,) CIRProblem(
+            0.1, 0.5, 0.2, 0.4, (0.0, 1.0))
+    end
+
+    @testset "CIRNoise type stability" begin
+        @test_opt target_modules = (DiffEqFinancial,) CIRNoise(
+            0.1, 0.5, 0.2, 0.0, 0.4)
+    end
+end


### PR DESCRIPTION
## Summary

- Remove deprecated `__precompile__()` call (no longer needed in modern Julia)
- Add JET.jl as a test dependency for type stability testing
- Add comprehensive JET static analysis tests for all problem constructors
- Wrap existing tests in proper `@testset` for better organization
- Update minimum Julia version to 1.10 (required for JET.jl)

## Changes

### Source Code
- Removed `__precompile__()` from `src/DiffEqFinancial.jl` - this is deprecated and no longer necessary in modern Julia

### Test Suite
- Added JET.jl type stability tests for:
  - `HestonProblem`
  - `GeometricBrownianMotionProblem`
  - `OrnsteinUhlenbeckProblem`
  - `CIRProblem`
  - `CIRNoise`
- Wrapped existing tests in `@testset` for better test organization
- Tests use `target_modules = (DiffEqFinancial,)` to filter out upstream SciMLBase/DiffEqBase issues

### Project.toml
- Added JET.jl (0.9, 0.10, 0.11) as a test dependency
- Updated Julia minimum version from 1.6 to 1.10 (JET.jl requirement)

## Analysis Results

The JET package analysis found that **all problem constructors in DiffEqFinancial are type-stable**. The only issues detected during sound analysis (`@test_call`) were from upstream SciMLBase.jl's `isinplace` function, which uses `Union{Missing, Bool}` types - these are filtered out in the test suite.

## Test plan

- [x] All existing tests pass
- [x] New JET tests pass
- [x] Verified with `Pkg.test()` locally

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)