### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqFinancial"
 uuid = "5a0ffddc-d203-54b0-88ba-2c03c0fc2e67"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.9.0"
+version = "2.10.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -11,7 +11,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 
 [compat]
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 DiffEqNoiseProcess = "5"
 Distributions = "0.25.100"
 RandomNumbers = "1"


### PR DESCRIPTION
## Summary

Widen `DiffEqBase = "6"` → `"6, 7"` so DiffEqFinancial resolves alongside `lib/DiffEqBase` v7 (OrdinaryDiffEq v7 release). Bumps 2.9.0 → 2.10.0.

`DiffEqNoiseProcess = "5"` already covers the 5.30 in SciML/DiffEqNoiseProcess.jl#271.

## Why this is source-level safe

Grepped `src/` clean for every symbol removed in the v7 NEWS / SciMLBase v3 breaking notes: `u_modified!`, `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`, `intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`. Zero matches.

## Scope

Part of the v7-compat-widening set alongside DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431, Sundials#526, ODEInterfaceDiffEq#95.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>