### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
       - "/test"
+      - "/test/nopre"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,9 @@ on:
 jobs:
   test:
     if: false  # Disabled: needs investigation. See #66 for details.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Moves all CI to the centralized SciML reusable workflows (pinned `@v1`, every caller passes `secrets: "inherit"`), matching the Sundials.jl end-state.

### Converted (inline -> central caller)
- **FormatCheck.yml** (Runic): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving `if: false` (issue #66), `julia-version: "1.10"`, `skip: "Pkg,TOML"` (default `allow-reresolve: false` matches the old `ALLOW_RERESOLVE: false`)

### Already central (unchanged)
- **Tests.yml** — already `tests.yml@v1` caller with the exact version×group matrix and `secrets: "inherit"`
- **Documentation.yml** — already `documentation.yml@v1` caller

### dependabot.yml
- Removed the `crate-ci/typos` version-update `ignore` block (the typos version is now pinned by the central spellcheck workflow)
- Added `/test/nopre` to the `julia` ecosystem `directories` (it has its own `Project.toml`); existing `/`, `/docs`, `/test` preserved

### Formatting / typos
- Ran Runic in place: no formatting changes (repo was already Runic-clean from the prior inline check)
- `typos .` reports clean (exit 0); 0 typos fixed; existing `.typos.toml` preserved

### Note on branch protection
The job/check names change (now run under the reusable workflow's job names, e.g. "Runic Format Check", "Spell Check with Typos", "Downgrade Tests"). Any required-status-check rules in branch protection will need updating to the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)