### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,10 +12,10 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false  # Disabled: needs investigation. See #66 for details.
     name: Downgrade
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
+      allow-reresolve: false
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -11,11 +11,11 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 
 [compat]
-DiffEqBase = "6, 7"
-DiffEqNoiseProcess = "5"
+DiffEqBase = "6.133.1, 7"
+DiffEqNoiseProcess = "5.13.0"
 Distributions = "0.25.100"
-RandomNumbers = "1"
-StochasticDiffEq = "6.28"
+RandomNumbers = "1.5.3"
+StochasticDiffEq = "6.65.0"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `DiffEqBase = "6.133.1, 7";DiffEqNoiseProcess = "5.13.0";RandomNumbers = "1.5.3";StochasticDiffEq = "6.65.0";`DiffEqBase = "6.133.1, 7";DiffEqNoiseProcess = "5.13.0";RandomNumbers = "1.5.3";StochasticDiffEq = "6.65.0";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)