### PR TITLE
Bump version to 2.10.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqFinancial"
 uuid = "5a0ffddc-d203-54b0-88ba-2c03c0fc2e67"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.10.1"
+version = "2.10.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Automated patch version bump (2.10.1 -> 2.10.2) to release unreleased commits on `master` via JuliaRegistrator.