### PR TITLE
Remove DiffEqFinancial Aqua QA exception

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,4 @@
 using SciMLTesting, DiffEqFinancial, Test
 using JET
 
-run_qa(
-    DiffEqFinancial;
-    aqua_kwargs = (; deps_compat = (; check_extras = false)),
-)
+run_qa(DiffEqFinancial)


### PR DESCRIPTION
## Summary
- remove the remaining `aqua_kwargs` exception from the SciMLTesting v2.4 QA harness
- run the package QA suite with exactly `run_qa(DiffEqFinancial)`

## Verification
- `Pkg.test()` on Julia 1.10.11
- strict SciMLTesting QA on Julia 1.10.11: 18/18 checks passed
- Documenter build and explicit doctests: 1/1 passed
- Runic `--check --diff src test docs`
- `git diff --check`

Please ignore until reviewed by @ChrisRackauckas.